### PR TITLE
send_sms to return message identifier / reference_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Supports Voodoo's API v2.1
     # => "15.0000"
 
     client.send_sms('SenderID', '440000000000', 'Message')
-    # => true
+    # => "5143598"
 
     messages = client.get_sms(Date.new(2014,10,17), Date.new(2014,10,17))
     # => [#<OpenStruct from="447000000006", timestamp=#<DateTime: 2014-10-17T15:32:58+00:00>, message="Inbound message body">]

--- a/spec/vcr_cassettes/success/get_credit_changed_response.yml
+++ b/spec/vcr_cassettes/success/get_credit_changed_response.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://voodoosms.com/vapi/server/sendSMS?dest=447123456789&format=json&msg=Test%20message&orig=SENDERID&pass=password&uid=username&validity=1
+    uri: http://voodoosms.com/vapi/server/getCredit?format=json&pass=password&uid=username
     body:
       encoding: US-ASCII
       string: ''
@@ -13,11 +13,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 17 Oct 2014 17:18:19 GMT
+      - Fri, 17 Oct 2014 15:21:40 GMT
       Server:
       - Apache
       Content-Length:
-      - '36'
+      - '38'
       X-Powered-By:
       - PleskLin
       Ms-Author-Via:
@@ -28,7 +28,7 @@ http_interactions:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"result":200,"resultText":"200 OK","reference_id": "4103395"}'
+      string: '{"result":"200 OK","credit_remaining":"123.0000"}'
     http_version:
-  recorded_at: Fri, 17 Oct 2014 17:18:19 GMT
+  recorded_at: Fri, 17 Oct 2014 15:21:40 GMT
 recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/success/send_multipart_sms.yml
+++ b/spec/vcr_cassettes/success/send_multipart_sms.yml
@@ -28,7 +28,7 @@ http_interactions:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"result":200,"resultText":"200 OK"}'
+      string: '{"result":200,"resultText":"200 OK","reference_id": "4103395"}'
     http_version:
   recorded_at: Fri, 17 Oct 2014 18:42:09 GMT
 recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/success/send_sms_response_changed.yml
+++ b/spec/vcr_cassettes/success/send_sms_response_changed.yml
@@ -28,7 +28,7 @@ http_interactions:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"result":200,"resultText":"200 OK","reference_id": "4103395"}'
+      string: '{"result":200,"resultText":"200 OK","message_id": "4103395"}'
     http_version:
   recorded_at: Fri, 17 Oct 2014 17:18:19 GMT
 recorded_with: VCR 2.9.3

--- a/voodoo_sms.gemspec
+++ b/voodoo_sms.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name        = 'voodoo_sms'
-  gem.version     = '0.0.2'
+  gem.version     = '1.0.0'
   gem.date        = '2014-10-17'
   gem.summary     = 'VoodooSMS API'
   gem.description = 'Ruby wrapper for VoodooSMS API'


### PR DESCRIPTION
alters send_sms, which now returns parsed_response containing message id / reference_id, instead of boolean true